### PR TITLE
openpgp: EdDSA support

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -346,7 +346,6 @@ EachPacket:
 		} else if err != nil {
 			return nil, err
 		}
-
 		switch pkt := p.(type) {
 		case *packet.UserId:
 			current = new(Identity)

--- a/openpgp/packet/packet.go
+++ b/openpgp/packet/packet.go
@@ -412,6 +412,8 @@ const (
 	// RFC 6637, Section 5.
 	PubKeyAlgoECDH  PublicKeyAlgorithm = 18
 	PubKeyAlgoECDSA PublicKeyAlgorithm = 19
+	// RFC -1
+	PubKeyAlgoEdDSA PublicKeyAlgorithm = 22
 )
 
 // CanEncrypt returns true if it's possible to encrypt a message to a public
@@ -428,7 +430,7 @@ func (pka PublicKeyAlgorithm) CanEncrypt() bool {
 // sign a message.
 func (pka PublicKeyAlgorithm) CanSign() bool {
 	switch pka {
-	case PubKeyAlgoRSA, PubKeyAlgoRSASignOnly, PubKeyAlgoDSA, PubKeyAlgoECDSA:
+	case PubKeyAlgoRSA, PubKeyAlgoRSASignOnly, PubKeyAlgoDSA, PubKeyAlgoECDSA, PubKeyAlgoEdDSA:
 		return true
 	}
 	return false

--- a/openpgp/packet/reader.go
+++ b/openpgp/packet/reader.go
@@ -46,7 +46,6 @@ func (r *Reader) Next() (p Packet, err error) {
 			return nil, err
 		}
 	}
-
 	return nil, io.EOF
 }
 

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -43,6 +43,7 @@ type Signature struct {
 	RSASignature         parsedMPI
 	DSASigR, DSASigS     parsedMPI
 	ECDSASigR, ECDSASigS parsedMPI
+	EdDSASigR, EdDSASigS parsedMPI
 
 	// rawSubpackets contains the unparsed subpackets, in order.
 	rawSubpackets []outputSubpacket
@@ -77,6 +78,15 @@ type Signature struct {
 	outSubpackets []outputSubpacket
 }
 
+// func eddsaValueFromReader() (ret []byte, err error) {
+//	var buf [2]byte
+//	_, err = readFull(r, buf[:2])
+//	if err != nil {
+//		return nil, err
+//	}
+//	bits := binary.BigEndian.Uint16(buf)
+// }
+
 func (sig *Signature) parse(r io.Reader) (err error) {
 	// RFC 4880, section 5.2.3
 	var buf [5]byte
@@ -96,7 +106,7 @@ func (sig *Signature) parse(r io.Reader) (err error) {
 	sig.SigType = SignatureType(buf[0])
 	sig.PubKeyAlgo = PublicKeyAlgorithm(buf[1])
 	switch sig.PubKeyAlgo {
-	case PubKeyAlgoRSA, PubKeyAlgoRSASignOnly, PubKeyAlgoDSA, PubKeyAlgoECDSA:
+	case PubKeyAlgoRSA, PubKeyAlgoRSASignOnly, PubKeyAlgoDSA, PubKeyAlgoECDSA, PubKeyAlgoEdDSA:
 	default:
 		err = errors.UnsupportedError("public key algorithm " + strconv.Itoa(int(sig.PubKeyAlgo)))
 		return
@@ -159,6 +169,11 @@ func (sig *Signature) parse(r io.Reader) (err error) {
 		sig.DSASigR.bytes, sig.DSASigR.bitLength, err = readMPI(r)
 		if err == nil {
 			sig.DSASigS.bytes, sig.DSASigS.bitLength, err = readMPI(r)
+		}
+	case PubKeyAlgoEdDSA:
+		sig.EdDSASigR.bytes, sig.EdDSASigR.bitLength, err = readMPI(r)
+		if err == nil {
+			sig.EdDSASigS.bytes, sig.EdDSASigS.bitLength, err = readMPI(r)
 		}
 	case PubKeyAlgoECDSA:
 		sig.ECDSASigR.bytes, sig.ECDSASigR.bitLength, err = readMPI(r)
@@ -579,6 +594,9 @@ func (sig *Signature) Serialize(w io.Writer) (err error) {
 	case PubKeyAlgoDSA:
 		sigLength = 2 + len(sig.DSASigR.bytes)
 		sigLength += 2 + len(sig.DSASigS.bytes)
+	case PubKeyAlgoEdDSA:
+		sigLength = 2 + len(sig.EdDSASigR.bytes)
+		sigLength += 2 + len(sig.EdDSASigS.bytes)
 	case PubKeyAlgoECDSA:
 		sigLength = 2 + len(sig.ECDSASigR.bytes)
 		sigLength += 2 + len(sig.ECDSASigS.bytes)
@@ -619,6 +637,8 @@ func (sig *Signature) Serialize(w io.Writer) (err error) {
 		err = writeMPIs(w, sig.RSASignature)
 	case PubKeyAlgoDSA:
 		err = writeMPIs(w, sig.DSASigR, sig.DSASigS)
+	case PubKeyAlgoEdDSA:
+		err = writeMPIs(w, sig.EdDSASigR, sig.EdDSASigS)
 	case PubKeyAlgoECDSA:
 		err = writeMPIs(w, sig.ECDSASigR, sig.ECDSASigS)
 	default:


### PR DESCRIPTION
Though support isn't official yet, some adventurous early adopters are trying it out.
- Spec is here: https://tools.ietf.org/html/draft-koch-eddsa-for-openpgp-00
