### PR TITLE
openpgp: fix crash when trying to serialize ed25519 public key

### DIFF
--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -438,6 +438,8 @@ func (pk *PublicKey) Serialize(w io.Writer) (err error) {
 	case PubKeyAlgoECDH:
 		length += pk.ec.byteLen()
 		length += pk.ecdh.byteLen()
+	case PubKeyAlgoEdDSA:
+		length += pk.edk.byteLen()
 	default:
 		panic("unknown public key algorithm")
 	}


### PR DESCRIPTION
When trying to login to keybase using an ed25519 public key, the client panics with "unknown public key algorithm". This is due to a missing case in `func (pk *PublicKey) Serialize`.

Steps to reproduce:
1. Create fresh installation of keybase
2. `keybase --standalone login` to an account with an ed25519 public key
