### PR TITLE
don't encrypt for DSA primary keys

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -95,6 +95,18 @@ func (e *Entity) encryptionKey(now time.Time) (Key, bool) {
 	// Iterate the keys to find the newest key
 	var maxTime time.Time
 	for i, subkey := range e.Subkeys {
+
+		// NOTE(maxtaco)
+		// If there is a Flags subpacket, then we have to follow it, and only
+		// use keys that are marked for Encryption of Communication.  If there
+		// isn't a Flags subpacket, and this is an Encrypt-Only key (right now only ElGamal
+		// suffices), then we implicitly use it. The check for primary below is a little
+		// more open-ended, but for now, let's be strict and potentially open up
+		// if we see bugs in the wild.
+		//
+		// One more note: old DSA/ElGamal keys tend not to have the Flags subpacket,
+		// so this sort of thing is pretty important for encrypting to older keys.
+		//
 		if ((subkey.Sig.FlagsValid && subkey.Sig.FlagEncryptCommunications) ||
 		    (!subkey.Sig.FlagsValid && subkey.PublicKey.PubKeyAlgo == packet.PubKeyAlgoElGamal)) &&
 			subkey.PublicKey.PubKeyAlgo.CanEncrypt() &&
@@ -114,6 +126,9 @@ func (e *Entity) encryptionKey(now time.Time) (Key, bool) {
 	// the primary key doesn't have any usage metadata then we
 	// assume that the primary key is ok. Or, if the primary key is
 	// marked as ok to encrypt to, then we can obviously use it.
+	//
+	// NOTE(maxtaco) - see note above, how this policy is a little too open-ended
+	// for my liking, but leave it for now.
 	i := e.primaryIdentity()
 	if (!i.SelfSignature.FlagsValid || i.SelfSignature.FlagEncryptCommunications) &&
 		e.PrimaryKey.PubKeyAlgo.CanEncrypt() &&


### PR DESCRIPTION
- and encrypt for ElGamal subkeys even if they're not explicitly called out as such
