### PR TITLE
Add support for public key algo 20 (Elgamal Encrypt and Sign)

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -116,7 +116,9 @@ func (e *Entity) encryptionKey(now time.Time) (Key, bool) {
 		// so this sort of thing is pretty important for encrypting to older keys.
 		//
 		if ((subkey.Sig.FlagsValid && subkey.Sig.FlagEncryptCommunications) ||
-			(!subkey.Sig.FlagsValid && subkey.PublicKey.PubKeyAlgo == packet.PubKeyAlgoElGamal)) &&
+			(!subkey.Sig.FlagsValid &&
+				(subkey.PublicKey.PubKeyAlgo == packet.PubKeyAlgoElGamal ||
+					subkey.PublicKey.PubKeyAlgo == packet.PubKeyAlgoElGamalEncAndSign))) &&
 			subkey.PublicKey.PubKeyAlgo.CanEncrypt() &&
 			!subkey.Sig.KeyExpired(now) &&
 			subkey.Revocation == nil &&

--- a/openpgp/packet/packet.go
+++ b/openpgp/packet/packet.go
@@ -411,8 +411,9 @@ const (
 	PubKeyAlgoElGamal        PublicKeyAlgorithm = 16
 	PubKeyAlgoDSA            PublicKeyAlgorithm = 17
 	// RFC 6637, Section 5.
-	PubKeyAlgoECDH  PublicKeyAlgorithm = 18
-	PubKeyAlgoECDSA PublicKeyAlgorithm = 19
+	PubKeyAlgoECDH              PublicKeyAlgorithm = 18
+	PubKeyAlgoECDSA             PublicKeyAlgorithm = 19
+	PubKeyAlgoElGamalEncAndSign PublicKeyAlgorithm = 20
 	// RFC -1
 	PubKeyAlgoEdDSA PublicKeyAlgorithm = 22
 )

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -286,7 +286,7 @@ func (pk *PrivateKey) parsePrivateKey(data []byte) (err error) {
 		return pk.parseRSAPrivateKey(data)
 	case PubKeyAlgoDSA:
 		return pk.parseDSAPrivateKey(data)
-	case PubKeyAlgoElGamal:
+	case PubKeyAlgoElGamal, PubKeyAlgoElGamalEncAndSign:
 		return pk.parseElGamalPrivateKey(data)
 	case PubKeyAlgoECDSA:
 		return pk.parseECDSAPrivateKey(data)

--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -314,7 +314,7 @@ func (pk *PublicKey) parse(r io.Reader) (err error) {
 		err = pk.parseRSA(r)
 	case PubKeyAlgoDSA:
 		err = pk.parseDSA(r)
-	case PubKeyAlgoElGamal:
+	case PubKeyAlgoElGamal, PubKeyAlgoElGamalEncAndSign:
 		err = pk.parseElGamal(r)
 	case PubKeyAlgoEdDSA:
 		pk.edk = &edDSAkey{}
@@ -454,7 +454,7 @@ func (pk *PublicKey) SerializeSignaturePrefix(h io.Writer) {
 		pLength += 2 + uint16(len(pk.q.bytes))
 		pLength += 2 + uint16(len(pk.g.bytes))
 		pLength += 2 + uint16(len(pk.y.bytes))
-	case PubKeyAlgoElGamal:
+	case PubKeyAlgoElGamal, PubKeyAlgoElGamalEncAndSign:
 		pLength += 2 + uint16(len(pk.p.bytes))
 		pLength += 2 + uint16(len(pk.g.bytes))
 		pLength += 2 + uint16(len(pk.y.bytes))
@@ -485,7 +485,7 @@ func (pk *PublicKey) Serialize(w io.Writer) (err error) {
 		length += 2 + len(pk.q.bytes)
 		length += 2 + len(pk.g.bytes)
 		length += 2 + len(pk.y.bytes)
-	case PubKeyAlgoElGamal:
+	case PubKeyAlgoElGamal, PubKeyAlgoElGamalEncAndSign:
 		length += 2 + len(pk.p.bytes)
 		length += 2 + len(pk.g.bytes)
 		length += 2 + len(pk.y.bytes)
@@ -533,7 +533,7 @@ func (pk *PublicKey) serializeWithoutHeaders(w io.Writer) (err error) {
 		return writeMPIs(w, pk.n, pk.e)
 	case PubKeyAlgoDSA:
 		return writeMPIs(w, pk.p, pk.q, pk.g, pk.y)
-	case PubKeyAlgoElGamal:
+	case PubKeyAlgoElGamal, PubKeyAlgoElGamalEncAndSign:
 		return writeMPIs(w, pk.p, pk.g, pk.y)
 	case PubKeyAlgoECDSA:
 		return pk.ec.serialize(w)
@@ -550,7 +550,7 @@ func (pk *PublicKey) serializeWithoutHeaders(w io.Writer) (err error) {
 
 // CanSign returns true iff this public key can generate signatures
 func (pk *PublicKey) CanSign() bool {
-	return pk.PubKeyAlgo != PubKeyAlgoRSAEncryptOnly && pk.PubKeyAlgo != PubKeyAlgoElGamal
+	return pk.PubKeyAlgo != PubKeyAlgoRSAEncryptOnly && pk.PubKeyAlgo != PubKeyAlgoElGamal && pk.PubKeyAlgo != PubKeyAlgoElGamalEncAndSign
 }
 
 // VerifySignature returns nil iff sig is a valid signature, made by this
@@ -831,7 +831,7 @@ func (pk *PublicKey) BitLength() (bitLength uint16, err error) {
 		bitLength = pk.n.bitLength
 	case PubKeyAlgoDSA:
 		bitLength = pk.p.bitLength
-	case PubKeyAlgoElGamal:
+	case PubKeyAlgoElGamal, PubKeyAlgoElGamalEncAndSign:
 		bitLength = pk.p.bitLength
 	default:
 		err = errors.InvalidArgumentError("bad public-key algorithm")

--- a/openpgp/read.go
+++ b/openpgp/read.go
@@ -113,7 +113,7 @@ ParsePackets:
 			// This packet contains the decryption key encrypted to a public key.
 			md.EncryptedToKeyIds = append(md.EncryptedToKeyIds, p.KeyId)
 			switch p.Algo {
-			case packet.PubKeyAlgoRSA, packet.PubKeyAlgoRSAEncryptOnly, packet.PubKeyAlgoElGamal:
+			case packet.PubKeyAlgoRSA, packet.PubKeyAlgoRSAEncryptOnly, packet.PubKeyAlgoElGamal, packet.PubKeyAlgoElGamalEncAndSign:
 				break
 			default:
 				continue


### PR DESCRIPTION
There are still older public keys out in the wild that use this older and by my understanding deprecated public key algorithm specifier. So far as I can tell from the older and newer versions of the RFC, this code (20) was used to specify Elgamal with "usage flags" of Encrypt and Sign. Code 16 was there as well but specified Elgamal for encryption only.

Being as though both codes use Elgamal, this patch simply provides pass-through for this older code (20) all the places in the code where code 16 was being checked.

I wanted to get a :+1:/:-1: on this approach first, then I'll add a test at least making sure we're able to parse public key packets using this code. I'm not sure how to test encryption or signing because I haven't figured out how to make a new key pair using this older algorithm. Any help with that would be appreciated!
