### PR TITLE
OpenPGP signature creation with external signing code

### DIFF
--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -661,14 +661,12 @@ func (pk *PublicKey) VerifySignatureV3(signed hash.Hash, sig *SignatureV3) (err 
 
 // keySignatureHash returns a Hash of the message that needs to be signed for
 // pk to assert a subkey relationship to signed.
-func keySignatureHash(pk, signed signingKey, h hash.Hash) (err error) {
-
+func keySignatureHash(pk, signed signingKey, h hash.Hash) {
 	// RFC 4880, section 5.2.4
 	pk.SerializeSignaturePrefix(h)
 	pk.serializeWithoutHeaders(h)
 	signed.SerializeSignaturePrefix(h)
 	signed.serializeWithoutHeaders(h)
-	return
 }
 
 // VerifyKeySignature returns nil iff sig is a valid signature, made by this
@@ -678,10 +676,8 @@ func (pk *PublicKey) VerifyKeySignature(signed *PublicKey, sig *Signature) error
 		return errors.UnsupportedError("hash function")
 	}
 	h := sig.Hash.New()
+	keySignatureHash(pk, signed, h)
 
-	if err := keySignatureHash(pk, signed, h); err != nil {
-		return err
-	}
 	if err := pk.VerifySignature(h, sig); err != nil {
 		return err
 	}
@@ -712,10 +708,8 @@ func (pk *PublicKey) VerifyKeySignature(signed *PublicKey, sig *Signature) error
 			return errors.UnsupportedError("hash function")
 		}
 		h := sig.EmbeddedSignature.Hash.New()
+		keySignatureHash(pk, signed, h)
 
-		if err := keySignatureHash(pk, signed, h); err != nil {
-			return errors.StructuralError("error while hashing for cross-signature: " + err.Error())
-		}
 		if err := signed.VerifySignature(h, sig.EmbeddedSignature); err != nil {
 			return errors.StructuralError("error while verifying cross-signature: " + err.Error())
 		}

--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -207,10 +207,17 @@ type signingKey interface {
 	serializeWithoutHeaders(io.Writer) error
 }
 
-func fromBig(n *big.Int) parsedMPI {
+func FromBig(n *big.Int) parsedMPI {
 	return parsedMPI{
 		bytes:     n.Bytes(),
 		bitLength: uint16(n.BitLen()),
+	}
+}
+
+func FromBytes(bytes []byte) parsedMPI {
+	return parsedMPI{
+		bytes:     bytes,
+		bitLength: uint16(8 * len(bytes)),
 	}
 }
 
@@ -220,8 +227,8 @@ func NewRSAPublicKey(creationTime time.Time, pub *rsa.PublicKey) *PublicKey {
 		CreationTime: creationTime,
 		PubKeyAlgo:   PubKeyAlgoRSA,
 		PublicKey:    pub,
-		n:            fromBig(pub.N),
-		e:            fromBig(big.NewInt(int64(pub.E))),
+		n:            FromBig(pub.N),
+		e:            FromBig(big.NewInt(int64(pub.E))),
 	}
 
 	pk.setFingerPrintAndKeyId()
@@ -234,10 +241,10 @@ func NewDSAPublicKey(creationTime time.Time, pub *dsa.PublicKey) *PublicKey {
 		CreationTime: creationTime,
 		PubKeyAlgo:   PubKeyAlgoDSA,
 		PublicKey:    pub,
-		p:            fromBig(pub.P),
-		q:            fromBig(pub.Q),
-		g:            fromBig(pub.G),
-		y:            fromBig(pub.Y),
+		p:            FromBig(pub.P),
+		q:            FromBig(pub.Q),
+		g:            FromBig(pub.G),
+		y:            FromBig(pub.Y),
 	}
 
 	pk.setFingerPrintAndKeyId()
@@ -260,9 +267,9 @@ func NewElGamalPublicKey(creationTime time.Time, pub *elgamal.PublicKey) *Public
 		CreationTime: creationTime,
 		PubKeyAlgo:   PubKeyAlgoElGamal,
 		PublicKey:    pub,
-		p:            fromBig(pub.P),
-		g:            fromBig(pub.G),
-		y:            fromBig(pub.Y),
+		p:            FromBig(pub.P),
+		g:            FromBig(pub.G),
+		y:            FromBig(pub.Y),
 	}
 
 	pk.setFingerPrintAndKeyId()

--- a/openpgp/packet/public_key_v3.go
+++ b/openpgp/packet/public_key_v3.go
@@ -42,8 +42,8 @@ func newRSAPublicKeyV3(creationTime time.Time, pub *rsa.PublicKey) *PublicKeyV3 
 	pk := &PublicKeyV3{
 		CreationTime: creationTime,
 		PublicKey:    pub,
-		n:            fromBig(pub.N),
-		e:            fromBig(big.NewInt(int64(pub.E))),
+		n:            FromBig(pub.N),
+		e:            FromBig(big.NewInt(int64(pub.E))),
 	}
 
 	pk.setFingerPrintAndKeyId()

--- a/openpgp/packet/public_key_v3.go
+++ b/openpgp/packet/public_key_v3.go
@@ -236,10 +236,8 @@ func (pk *PublicKeyV3) VerifyKeySignatureV3(signed *PublicKeyV3, sig *SignatureV
 		return errors.UnsupportedError("hash function")
 	}
 	h := sig.Hash.New()
+	keySignatureHash(pk, signed, h)
 
-	if err = keySignatureHash(pk, signed, h); err != nil {
-		return err
-	}
 	return pk.VerifySignatureV3(h, sig)
 }
 

--- a/openpgp/packet/public_key_v3.go
+++ b/openpgp/packet/public_key_v3.go
@@ -232,11 +232,10 @@ func (pk *PublicKeyV3) VerifyUserIdSignatureV3(id string, pub *PublicKeyV3, sig 
 // VerifyKeySignatureV3 returns nil iff sig is a valid signature, made by this
 // public key, of signed.
 func (pk *PublicKeyV3) VerifyKeySignatureV3(signed *PublicKeyV3, sig *SignatureV3) (err error) {
-	if !sig.Hash.Available() {
-		return errors.UnsupportedError("hash function")
+	h, err := newKeySignatureHash(pk, signed, sig.Hash)
+	if err != nil {
+		return err
 	}
-	h := sig.Hash.New()
-	keySignatureHash(pk, signed, h)
 
 	return pk.VerifySignatureV3(h, sig)
 }

--- a/openpgp/packet/public_key_v3.go
+++ b/openpgp/packet/public_key_v3.go
@@ -232,7 +232,7 @@ func (pk *PublicKeyV3) VerifyUserIdSignatureV3(id string, pub *PublicKeyV3, sig 
 // VerifyKeySignatureV3 returns nil iff sig is a valid signature, made by this
 // public key, of signed.
 func (pk *PublicKeyV3) VerifyKeySignatureV3(signed *PublicKeyV3, sig *SignatureV3) (err error) {
-	h, err := newKeySignatureHash(pk, signed, sig.Hash)
+	h, err := keySignatureHash(pk, signed, sig.Hash)
 	if err != nil {
 		return err
 	}

--- a/openpgp/packet/public_key_v3.go
+++ b/openpgp/packet/public_key_v3.go
@@ -236,7 +236,6 @@ func (pk *PublicKeyV3) VerifyKeySignatureV3(signed *PublicKeyV3, sig *SignatureV
 	if err != nil {
 		return err
 	}
-
 	return pk.VerifySignatureV3(h, sig)
 }
 

--- a/openpgp/packet/public_key_v3.go
+++ b/openpgp/packet/public_key_v3.go
@@ -232,8 +232,12 @@ func (pk *PublicKeyV3) VerifyUserIdSignatureV3(id string, pub *PublicKeyV3, sig 
 // VerifyKeySignatureV3 returns nil iff sig is a valid signature, made by this
 // public key, of signed.
 func (pk *PublicKeyV3) VerifyKeySignatureV3(signed *PublicKeyV3, sig *SignatureV3) (err error) {
-	h, err := keySignatureHash(pk, signed, sig.Hash)
-	if err != nil {
+	if !sig.Hash.Available() {
+		return errors.UnsupportedError("hash function")
+	}
+	h := sig.Hash.New()
+
+	if err = keySignatureHash(pk, signed, h); err != nil {
 		return err
 	}
 	return pk.VerifySignatureV3(h, sig)

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -602,7 +602,7 @@ func (sig *Signature) Sign(h hash.Hash, priv *PrivateKey, config *Config) (err e
 // Serialize to write it out.
 // If config is nil, sensible defaults will be used.
 func (sig *Signature) SignUserId(id string, pub *PublicKey, priv *PrivateKey, config *Config) error {
-	h, err := newUserIdSignatureHash(id, pub, sig.Hash)
+	h, err := userIdSignatureHash(id, pub, sig.Hash)
 	if err != nil {
 		return nil
 	}
@@ -614,7 +614,7 @@ func (sig *Signature) SignUserId(id string, pub *PublicKey, priv *PrivateKey, co
 // Call Serialize to write it out.
 // If config is nil, sensible defaults will be used.
 func (sig *Signature) SignUserIdWithSigner(id string, pub *PublicKey, s Signer, config *Config) error {
-	userIdSignatureHash(id, pub, s)
+	updateUserIdSignatureHash(id, pub, s)
 
 	return sig.Sign(s, nil, config)
 }
@@ -623,7 +623,7 @@ func (sig *Signature) SignUserIdWithSigner(id string, pub *PublicKey, s Signer, 
 // success, the signature is stored in sig. Call Serialize to write it out.
 // If config is nil, sensible defaults will be used.
 func (sig *Signature) SignKey(pub *PublicKey, priv *PrivateKey, config *Config) error {
-	h, err := newKeySignatureHash(&priv.PublicKey, pub, sig.Hash)
+	h, err := keySignatureHash(&priv.PublicKey, pub, sig.Hash)
 	if err != nil {
 		return err
 	}
@@ -635,7 +635,7 @@ func (sig *Signature) SignKey(pub *PublicKey, priv *PrivateKey, config *Config) 
 // success, the signature is stored in sig. Call Serialize to write it out.
 // If config is nil, sensible defaults will be used.
 func (sig *Signature) SignKeyWithSigner(signeePubKey *PublicKey, signerPubKey *PublicKey, s Signer, config *Config) error {
-	keySignatureHash(signerPubKey, signeePubKey, s)
+	updateKeySignatureHash(signerPubKey, signeePubKey, s)
 
 	return sig.Sign(s, nil, config)
 }

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -549,7 +549,7 @@ func (sig *Signature) signPrepareHash(h hash.Hash) (digest []byte, err error) {
 func (sig *Signature) Sign(h hash.Hash, priv *PrivateKey, config *Config) (err error) {
 	signer, hashIsSigner := h.(Signer)
 
-	if !hashIsSigner && priv.PrivateKey == nil {
+	if !hashIsSigner && (priv == nil || priv.PrivateKey == nil) {
 		err = errors.InvalidArgumentError("attempting to sign with nil PrivateKey")
 		return
 	}

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -627,7 +627,6 @@ func (sig *Signature) SignKey(pub *PublicKey, priv *PrivateKey, config *Config) 
 	if err != nil {
 		return err
 	}
-
 	return sig.Sign(h, priv, config)
 }
 

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -630,9 +630,9 @@ func (sig *Signature) SignKey(pub *PublicKey, priv *PrivateKey, config *Config) 
 	return sig.Sign(h, priv, config)
 }
 
-// SignKey computes a signature from priv, asserting that pub is a subkey. On
-// success, the signature is stored in sig. Call Serialize to write it out.
-// If config is nil, sensible defaults will be used.
+// SignKeyWithSigner computes a signature using s, asserting that
+// signeePubKey is a subkey. On success, the signature is stored in sig. Call
+// Serialize to write it out. If config is nil, sensible defaults will be used.
 func (sig *Signature) SignKeyWithSigner(signeePubKey *PublicKey, signerPubKey *PublicKey, s Signer, config *Config) error {
 	updateKeySignatureHash(signerPubKey, signeePubKey, s)
 

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -630,11 +630,10 @@ func (sig *Signature) SignUserIdWithSigner(id string, pub *PublicKey, s Signer, 
 // success, the signature is stored in sig. Call Serialize to write it out.
 // If config is nil, sensible defaults will be used.
 func (sig *Signature) SignKey(pub *PublicKey, priv *PrivateKey, config *Config) error {
-	if !sig.Hash.Available() {
-		return errors.UnsupportedError("hash function")
+	h, err := newKeySignatureHash(&priv.PublicKey, pub, sig.Hash)
+	if err != nil {
+		return err
 	}
-	h := sig.Hash.New()
-	keySignatureHash(&priv.PublicKey, pub, h)
 
 	return sig.Sign(h, priv, config)
 }

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -634,10 +634,8 @@ func (sig *Signature) SignKey(pub *PublicKey, priv *PrivateKey, config *Config) 
 		return errors.UnsupportedError("hash function")
 	}
 	h := sig.Hash.New()
+	keySignatureHash(&priv.PublicKey, pub, h)
 
-	if err := keySignatureHash(&priv.PublicKey, pub, h); err != nil {
-		return err
-	}
 	return sig.Sign(h, priv, config)
 }
 
@@ -645,9 +643,8 @@ func (sig *Signature) SignKey(pub *PublicKey, priv *PrivateKey, config *Config) 
 // success, the signature is stored in sig. Call Serialize to write it out.
 // If config is nil, sensible defaults will be used.
 func (sig *Signature) SignKeyWithSigner(signeePubKey *PublicKey, signerPubKey *PublicKey, s Signer, config *Config) error {
-	if err := keySignatureHash(signerPubKey, signeePubKey, s); err != nil {
-		return err
-	}
+	keySignatureHash(signerPubKey, signeePubKey, s)
+
 	return sig.Sign(s, nil, config)
 }
 

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -602,12 +602,7 @@ func (sig *Signature) Sign(h hash.Hash, priv *PrivateKey, config *Config) (err e
 // Serialize to write it out.
 // If config is nil, sensible defaults will be used.
 func (sig *Signature) SignUserId(id string, pub *PublicKey, priv *PrivateKey, config *Config) error {
-	if !sig.Hash.Available() {
-		return errors.UnsupportedError("hash function")
-	}
-	h := sig.Hash.New()
-
-	err := userIdSignatureHash(id, pub, h)
+	h, err := newUserIdSignatureHash(id, pub, sig.Hash)
 	if err != nil {
 		return nil
 	}
@@ -619,10 +614,8 @@ func (sig *Signature) SignUserId(id string, pub *PublicKey, priv *PrivateKey, co
 // Call Serialize to write it out.
 // If config is nil, sensible defaults will be used.
 func (sig *Signature) SignUserIdWithSigner(id string, pub *PublicKey, s Signer, config *Config) error {
-	err := userIdSignatureHash(id, pub, s)
-	if err != nil {
-		return nil
-	}
+	userIdSignatureHash(id, pub, s)
+
 	return sig.Sign(s, nil, config)
 }
 

--- a/openpgp/packet/signature_test.go
+++ b/openpgp/packet/signature_test.go
@@ -9,6 +9,8 @@ import (
 	"crypto"
 	"encoding/hex"
 	"testing"
+
+	"github.com/keybase/go-crypto/openpgp/errors"
 )
 
 func TestSignatureRead(t *testing.T) {
@@ -36,6 +38,36 @@ func TestSignatureReserialize(t *testing.T) {
 	expected, _ := hex.DecodeString(signatureDataHex)
 	if !bytes.Equal(expected, out.Bytes()) {
 		t.Errorf("output doesn't match input (got vs expected):\n%s\n%s", hex.Dump(out.Bytes()), hex.Dump(expected))
+	}
+}
+
+func TestSignWithNilPrivateKey(t *testing.T) {
+	sig := new(Signature)
+	hash := crypto.SHA256.New()
+
+	err := sig.Sign(hash, nil, nil)
+	if err == nil {
+		t.Error("expected error")
+		return
+	}
+
+	_, isInvalidArgumentError := err.(errors.InvalidArgumentError)
+	if !isInvalidArgumentError {
+		t.Error("expected InvalidArgumentError")
+		return
+	}
+
+	priv := new(PrivateKey)
+	err = sig.Sign(hash, priv, nil)
+	if err == nil {
+		t.Error("expected error")
+		return
+	}
+
+	_, isInvalidArgumentError = err.(errors.InvalidArgumentError)
+	if !isInvalidArgumentError {
+		t.Error("expected InvalidArgumentError")
+		return
 	}
 }
 

--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -68,11 +68,6 @@ func SignWithSigner(s packet.Signer, w io.Writer, message io.Reader, sigType pac
 	sig.CreationTime = config.Now()
 	sig.IssuerKeyId = &keyId
 
-	err = s.SetHashAlgorithm(sig.Hash)
-	if err != nil {
-		return
-	}
-
 	s.Reset()
 
 	wrapped := s.(hash.Hash)

--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -59,6 +59,9 @@ func armoredDetachSign(w io.Writer, signer *Entity, message io.Reader, sigType p
 	return out.Close()
 }
 
+// SignWithSigner signs the message of type sigType with s and writes the
+// signature to w.
+// If config is nil, sensible defaults will be used.
 func SignWithSigner(s packet.Signer, w io.Writer, message io.Reader, sigType packet.SignatureType, config *packet.Config) (err error) {
 	keyId := s.KeyId()
 	sig := new(packet.Signature)


### PR DESCRIPTION
We're wanting to make OpenPGP signatures using a HSM to do the actual RSA signing via PKCS#11. This isn't feasible (possible?) with the current APIs.

This PR adds a new `Signer` interface, allowing application code to decide how the actual signature is created:

``` go
type Signer interface {
    Sign(sig *Signature, msg []byte) error
    KeyId() uint64
    PublicKeyAlgo() PublicKeyAlgorithm
}
```

It also adds `openpgp.SignWithSigner` and `packet.Signature#SignWithSigner` functions for making detached signatures using the new interface. The code for these is mostly borrowed from `openpgp.detachSign` and `packet.Signature#Sign`, except the actual signing is delegated to the `Signer`.

I tried to make this general enough that it would work for other use cases. I'm curious what others think.

/cc @brianmario
