### PR TITLE
Handle invalid sig flags for ECDSA and EdDSA

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -286,6 +286,12 @@ func (el EntityList) KeysByIdUsage(id uint64, fp []byte, requiredUsage byte) (ke
 			case key.PublicKey.PubKeyAlgo == packet.PubKeyAlgoDSA:
 				usage |= packet.KeyFlagSign
 
+			case key.PublicKey.PubKeyAlgo == packet.PubKeyAlgoECDSA:
+				usage |= packet.KeyFlagSign
+
+			case key.PublicKey.PubKeyAlgo == packet.PubKeyAlgoEdDSA:
+				usage |= packet.KeyFlagSign
+
 			// For a primary RSA key without any key flags, be as permissiable
 			// as possible.
 			case key.PublicKey.PubKeyAlgo == packet.PubKeyAlgoRSA &&


### PR DESCRIPTION
~~the question is, where and how do we not write valid sig flags to the signatures~~