### PR TITLE
Ed25519 changes for Sign (use GenerateKey), add test case for short EDDSA signatures

### DIFF
--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -72,6 +72,11 @@ func (e *edDSAkey) Verify(payload []byte, r parsedMPI, s parsedMPI) bool {
 	// reading and keep only actual number in p field. Find out how
 	// other MPIs are stored.
 	key := e.p.bytes[1:]
+
+	// Note: it may happen that R + S do not form 64-byte signature buffer that
+	// ed25519 expects, but because we copy it over to an array of exact size,
+	// we will always pass correctly sized slice to Verify. Slice too short
+	// would make ed25519 panic().
 	n := copy(sig[:], r.bytes)
 	copy(sig[n:], s.bytes)
 


### PR DESCRIPTION
Adds a minimal repro test case with key similar to one from https://github.com/keybase/keybase-issues/issues/2787#issuecomment-285684184

Use `ed25519.GenerateKey` instead of creating key buffer from `priv+pub` manually.