### PR TITLE
Add a packet.PrivateKey.Encrypt() method

### DIFF
--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -162,10 +162,11 @@ func mod64kHash(d []byte) uint16 {
 	return h
 }
 
-// This is the counterpart to the Decrypt() method below.
-// If config is nil, then the standard, and sensible, defaults apply.
-// The typical usage is to call Encrypt() on a PrivateKey. An encryption
-// key will be derived from the given passphrase using S2K Specifier
+// Encrypt is the counterpart to the Decrypt() method below. It encrypts
+// the private key with the provided passphrase. If config is nil, then
+// the standard, and sensible, defaults apply.
+//
+// A key will be derived from the given passphrase using S2K Specifier
 // Type 3 (Iterated + Salted, see RFC-4880 Sec. 3.7.1.3). This choice
 // is hardcoded in s2k.Serialize(). S2KCount is hardcoded to 0, which is
 // equivalent to 65536. And the hash algorithm for key-derivation can be
@@ -181,7 +182,7 @@ func (pk *PrivateKey) Encrypt(passphrase []byte, config *Config) (err error) {
 	pk.sha1Checksum = true
 	pk.cipher = config.Cipher()
 	s2kConfig := s2k.Config{
-		Hash: config.Hash(),
+		Hash:     config.Hash(),
 		S2KCount: 0,
 	}
 	s2kBuf := bytes.NewBuffer(nil)
@@ -217,7 +218,6 @@ func (pk *PrivateKey) Encrypt(passphrase []byte, config *Config) (err error) {
 }
 
 func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
-	// TODO(agl): support encrypted private keys
 	buf := bytes.NewBuffer(nil)
 	err = pk.PublicKey.serializeWithoutHeaders(buf)
 	if err != nil {

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -177,8 +177,8 @@ func (pk *PrivateKey) Encrypt(passphrase []byte, config *Config) (err error) {
 	pk.sha1Checksum = true
 	pk.cipher = config.Cipher()
 	s2kConfig := s2k.Config{
-		config.Hash(),
-		0,
+		Hash: config.Hash(),
+		S2KCount: 0,
 	}
 	s2kBuf := bytes.NewBuffer(nil)
 	derivedKey := make([]byte, pk.cipher.KeySize())

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -193,6 +193,10 @@ func (pk *PrivateKey) Encrypt(passphrase []byte, config *Config) (err error) {
 	}
 
 	pk.s2kHeader = s2kBuf.Bytes()
+	// No good way to set pk.s2k but to call s2k.Parse(),
+	// even though we have all the information here, but
+	// most of the functions needed are private to s2k.
+	pk.s2k, err = s2k.Parse(s2kBuf)
 	pk.iv = make([]byte, pk.cipher.blockSize())
 	if _, err = config.Random().Read(pk.iv); err != nil {
 		return err

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -36,6 +36,7 @@ type PrivateKey struct {
 	PrivateKey    interface{} // An *rsa.PrivateKey or *dsa.PrivateKey.
 	sha1Checksum  bool
 	iv            []byte
+	s2kHeader     []byte
 }
 
 type EdDSAPrivateKey struct {
@@ -161,6 +162,56 @@ func mod64kHash(d []byte) uint16 {
 	return h
 }
 
+// This is the counterpart to the Decrypt() method below
+// @param passphase is the passphrase used to generate the derived-key based
+//        on the Iterated S2K method [Required]
+// @param config the packet.Config for setting encryption algorithm and hash
+//        algorithm. If it is nil, then the standard default will be used.
+// The typical usage is to call Encrypt() on an unprotected PrivateKey. Then
+// when Serialize() is called, the encryptedData member will be serialized
+func (pk *PrivateKey) Encrypt(passphrase []byte, config *Config) (err error) {
+	if pk.PrivateKey == nil {
+		return errors.InvalidArgumentError("there is no private key to encrypt")
+	}
+
+	pk.sha1Checksum = true
+	pk.cipher = config.Cipher()
+	s2kConfig := s2k.Config{
+		config.Hash(),
+		0,
+	}
+	s2kBuf := bytes.NewBuffer(nil)
+	derivedKey := make([]byte, pk.cipher.KeySize())
+	err = s2k.Serialize(s2kBuf, derivedKey, config.Random(), passphrase, &s2kConfig)
+	if err != nil {
+		return err
+	}
+
+	pk.s2kHeader = s2kBuf.Bytes()
+	pk.iv = make([]byte, pk.cipher.blockSize())
+	if _, err = config.Random().Read(pk.iv); err != nil {
+		return err
+	}
+
+	privateKeyBuf := bytes.NewBuffer(nil)
+	if err = pk.serializePrivateKey(privateKeyBuf); err != nil {
+		return err
+	}
+
+	checksum := sha1.Sum(privateKeyBuf.Bytes())
+	if _, err = privateKeyBuf.Write(checksum[:]); err != nil {
+		return err
+	}
+
+	pkData := privateKeyBuf.Bytes()
+	block := pk.cipher.new(derivedKey)
+	pk.encryptedData = make([]byte, len(pkData))
+	cfb := cipher.NewCFBEncrypter(block, pk.iv)
+	cfb.XORKeyStream(pk.encryptedData, pkData)
+	pk.Encrypted = true
+	return nil
+}
+
 func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 	// TODO(agl): support encrypted private keys
 	buf := bytes.NewBuffer(nil)
@@ -180,27 +231,27 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 			'G', 'N', 'U', // "GNU" as a string
 			1, // Extension type 1001 (minus 1000)
 		})
+	} else if pk.Encrypted {
+		_, err = buf.Write([]byte{
+			254,             // SHA-1 Convention
+			byte(pk.cipher), // Encryption scheme
+		})
+		if err != nil {
+			return err
+		}
+		if _, err = buf.Write(pk.s2kHeader); err != nil {
+			return err
+		}
+		if _, err = buf.Write(pk.iv); err != nil {
+			return err
+		}
+		if _, err = privateKeyBuf.Write(pk.encryptedData); err != nil {
+			return err
+		}
 	} else {
 		buf.WriteByte(0 /* no encryption */)
-
-		switch priv := pk.PrivateKey.(type) {
-		case *rsa.PrivateKey:
-			err = serializeRSAPrivateKey(privateKeyBuf, priv)
-		case *dsa.PrivateKey:
-			err = serializeDSAPrivateKey(privateKeyBuf, priv)
-		case *elgamal.PrivateKey:
-			err = serializeElGamalPrivateKey(privateKeyBuf, priv)
-		case *ecdsa.PrivateKey:
-			err = serializeECDSAPrivateKey(privateKeyBuf, priv)
-		case *ecdh.PrivateKey:
-			err = serializeECDHPrivateKey(privateKeyBuf, priv)
-		case *EdDSAPrivateKey:
-			err = serializeEdDSAPrivateKey(privateKeyBuf, priv)
-		default:
-			err = errors.InvalidArgumentError("unknown private key type")
-		}
-		if err != nil {
-			return
+		if err = pk.serializePrivateKey(privateKeyBuf); err != nil {
+			return err
 		}
 	}
 
@@ -210,7 +261,11 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 	if pk.IsSubkey {
 		ptype = packetTypePrivateSubkey
 	}
-	err = serializeHeader(w, ptype, len(contents)+len(privateKeyBytes)+2)
+	totalLen := len(contents) + len(privateKeyBytes)
+	if !pk.Encrypted {
+		totalLen += 2
+	}
+	err = serializeHeader(w, ptype, totalLen)
 	if err != nil {
 		return
 	}
@@ -223,7 +278,7 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 		return
 	}
 
-	if len(privateKeyBytes) > 0 {
+	if len(privateKeyBytes) > 0 && !pk.Encrypted {
 		checksum := mod64kHash(privateKeyBytes)
 		var checksumBytes [2]byte
 		checksumBytes[0] = byte(checksum >> 8)
@@ -232,6 +287,27 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 	}
 
 	return
+}
+
+func (pk *PrivateKey) serializePrivateKey(w io.Writer) (err error) {
+	switch priv := pk.PrivateKey.(type) {
+	case *rsa.PrivateKey:
+		err = serializeRSAPrivateKey(w, priv)
+	case *dsa.PrivateKey:
+		err = serializeDSAPrivateKey(w, priv)
+	case *elgamal.PrivateKey:
+		err = serializeElGamalPrivateKey(w, priv)
+	case *ecdsa.PrivateKey:
+		err = serializeECDSAPrivateKey(w, priv)
+	case *ecdh.PrivateKey:
+		err = serializeECDHPrivateKey(w, priv)
+	case *EdDSAPrivateKey:
+		err = serializeEdDSAPrivateKey(w, priv)
+	default:
+		err = errors.InvalidArgumentError("unknown private key type")
+	}
+
+	return err
 }
 
 func serializeRSAPrivateKey(w io.Writer, priv *rsa.PrivateKey) error {

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -162,13 +162,17 @@ func mod64kHash(d []byte) uint16 {
 	return h
 }
 
-// This is the counterpart to the Decrypt() method below
-// @param passphase is the passphrase used to generate the derived-key based
-//        on the Iterated S2K method [Required]
-// @param config the packet.Config for setting encryption algorithm and hash
-//        algorithm. If it is nil, then the standard default will be used.
-// The typical usage is to call Encrypt() on an unprotected PrivateKey. Then
-// when Serialize() is called, the encryptedData member will be serialized
+// This is the counterpart to the Decrypt() method below.
+// If config is nil, then the standard, and sensible, defaults apply.
+// The typical usage is to call Encrypt() on a PrivateKey. An encryption
+// key will be derived from the given passphrase using S2K Specifier
+// Type 3 (Iterated + Salted, see RFC-4880 Sec. 3.7.1.3). This choice
+// is hardcoded in s2k.Serialize(). S2KCount is hardcoded to 0, which is
+// equivalent to 65536. And the hash algorithm for key-derivation can be
+// set with config. The encrypted PrivateKey, using the algorithm specified
+// in config (if provided), is written out to the encryptedData member.
+// When Serialize() is called, this encryptedData member will be
+// serialized, using S2K Usage value of 254, and thus SHA1 checksum.
 func (pk *PrivateKey) Encrypt(passphrase []byte, config *Config) (err error) {
 	if pk.PrivateKey == nil {
 		return errors.InvalidArgumentError("there is no private key to encrypt")

--- a/openpgp/packet/private_key_test.go
+++ b/openpgp/packet/private_key_test.go
@@ -5,8 +5,15 @@
 package packet
 
 import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"math/big"
 	"testing"
 	"time"
+
+	"github.com/keybase/go-crypto/openpgp/elgamal"
+	"github.com/keybase/go-crypto/rsa"
 )
 
 var privateKeyTests = []struct {
@@ -22,6 +29,8 @@ var privateKeyTests = []struct {
 		time.Unix(0x4df9ee1a, 0),
 	},
 }
+
+var message = []byte("This is a test")
 
 func TestPrivateKeyRead(t *testing.T) {
 	for i, test := range privateKeyTests {
@@ -52,6 +61,77 @@ func TestPrivateKeyRead(t *testing.T) {
 
 		if !privKey.CreationTime.Equal(test.creationTime) || privKey.Encrypted {
 			t.Errorf("#%d: bad result, got: %#v", i, privKey)
+		}
+	}
+}
+
+func TestPrivateKeyEncrypt(t *testing.T) {
+	var encryptedMsg, decryptedMsg []byte
+	var encryptedC1, encryptedC2 *big.Int
+
+	for i, test := range privateKeyTests {
+		packet, err := Read(readerFromHex(test.privateKeyHex))
+		if err != nil {
+			t.Errorf("#%d: failed to parse: %s", i, err)
+			continue
+		}
+		privKey := packet.(*PrivateKey)
+		err = privKey.Decrypt([]byte("testing"))
+		if err != nil {
+			t.Errorf("#%d: failed to decrypt: %s", i, err)
+			continue
+		}
+
+		switch pubKey := privKey.PublicKey.PublicKey.(type) {
+		case *rsa.PublicKey:
+			encryptedMsg, err = rsa.EncryptPKCS1v15(rand.Reader, pubKey, message)
+			if err != nil {
+				t.Errorf("#%d: failed to encrypt message: %s", i, err)
+				continue
+			}
+		case *elgamal.PublicKey:
+			encryptedC1, encryptedC2, err = elgamal.Encrypt(rand.Reader, pubKey, message)
+			if err != nil {
+				t.Errorf("#%d: failed to encrypt message: %s", i, err)
+				continue
+			}
+		}
+
+		outbuf := bytes.NewBuffer(nil)
+		privKey.Encrypt([]byte("testingagain"), nil)
+		err = privKey.Serialize(outbuf)
+		if err != nil {
+			t.Errorf("#%d: failed to serialize: %s", i, err)
+			continue
+		}
+		newHex := hex.EncodeToString(outbuf.Bytes())
+		packet2, err2 := Read(readerFromHex(newHex))
+		if err2 != nil {
+			t.Errorf("#%d: failed to parse: %s", i, err2)
+		}
+		pKey := packet2.(*PrivateKey)
+		err2 = pKey.Decrypt([]byte("testingagain"))
+		if err2 != nil {
+			t.Errorf("#%d: failed to decrypt: %s", i, err2)
+			continue
+		}
+
+		switch prvKey := pKey.PrivateKey.(type) {
+		case *rsa.PrivateKey:
+			decryptedMsg, err = rsa.DecryptPKCS1v15(rand.Reader, prvKey, encryptedMsg)
+			if err != nil {
+				t.Errorf("#%d: failed to decrypt message: %s", i, err)
+				continue
+			}
+		case *elgamal.PrivateKey:
+			decryptedMsg, err = elgamal.Decrypt(prvKey, encryptedC1, encryptedC2)
+			if err != nil {
+				t.Error("#%d: failed to decrypt message: %s", i, err)
+			}
+		}
+		if !bytes.Equal(decryptedMsg, message) {
+			t.Errorf("#%d: decrypted message does not equal original", i)
+			continue
 		}
 	}
 }


### PR DESCRIPTION
This is the counterpart to the packet.PrivateKey.Decrypt() method.
The intention is to produce a password-protected PrivateKey that
can be serialized.

* S2K Usage is always 254 (RFC-4880 5.5.3)
* S2K Specifier Type is always Iterated and Salted
  (RFC-4880 3.7.1.3)