### PR TITLE
Mind expiry date when looking for sig for subkey

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -600,8 +600,9 @@ func addSubkey(e *Entity, packets *packet.Reader, pub *packet.PublicKey, priv *p
 		}
 		switch sig.SigType {
 		case packet.SigTypeSubkeyBinding:
-			// First writer wins
-			if subKey.Sig == nil {
+			// Does the "new" sig set expiration to later date than
+			// "previous" sig?
+			if subKey.Sig == nil || subKey.Sig.ExpiresBeforeOther(sig) {
 				subKey.Sig = sig
 			}
 		case packet.SigTypeSubkeyRevocation:

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -508,6 +508,26 @@ func (sig *Signature) KeyExpired(currentTime time.Time) bool {
 	return currentTime.After(expiry)
 }
 
+// ExpiresBeforeOther checks if other signature has expiration at
+// later date than sig.
+func (sig *Signature) ExpiresBeforeOther(other *Signature) bool {
+	if sig.KeyLifetimeSecs == nil {
+		// This sig never expires, or has infinitely long expiration
+		// time.
+		return false
+	} else if other.KeyLifetimeSecs == nil {
+		// This sig expires at some non-infinite point, but the other
+		// sig never expires.
+		return true
+	}
+
+	getExpiryDate := func(s *Signature) time.Time {
+		return s.CreationTime.Add(time.Duration(*s.KeyLifetimeSecs) * time.Second)
+	}
+
+	return getExpiryDate(other).After(getExpiryDate(sig))
+}
+
 // buildHashSuffix constructs the HashSuffix member of sig in preparation for signing.
 func (sig *Signature) buildHashSuffix() (err error) {
 	hashedSubpacketsLen := subpacketsLength(sig.outSubpackets, true)


### PR DESCRIPTION
When parsing keys, take the signature with furthest expiration date,
instead of the first signature that comes along.

Fixes: https://github.com/keybase/keybase-issues/issues/2604
Internal ticket: CORE-3879

@oconnor663 Please review, thank you!