### PR TITLE
Trim whitespace during armor decoding

### DIFF
--- a/openpgp/armor/armor.go
+++ b/openpgp/armor/armor.go
@@ -71,6 +71,13 @@ type lineReader struct {
 	crc *uint32
 }
 
+// ourIsSpace checks if a rune is either space according to unicode
+// package, or ZeroWidthSpace (which is not a space according to
+// unicode module). Used to trim lines during header reading.
+func ourIsSpace(r rune) bool {
+	return r == '\u200b' || unicode.IsSpace(r)
+}
+
 func (l *lineReader) Read(p []byte) (n int, err error) {
 	if l.eof {
 		return 0, io.EOF
@@ -86,6 +93,8 @@ func (l *lineReader) Read(p []byte) (n int, err error) {
 	if err != nil {
 		return
 	}
+
+	line = bytes.TrimFunc(line, ourIsSpace)
 
 	if len(line) == 5 && line[0] == '=' {
 		// This is the checksum line
@@ -157,13 +166,6 @@ func (r *openpgpReader) Read(p []byte) (n int, err error) {
 	}
 
 	return
-}
-
-// ourIsSpace checks if a rune is either space according to unicode
-// package, or ZeroWidthSpace (which is not a space according to
-// unicode module). Used to trim lines during header reading.
-func ourIsSpace(r rune) bool {
-	return r == '\u200b' || unicode.IsSpace(r)
 }
 
 // Decode reads a PGP armored block from the given Reader. It will ignore

--- a/openpgp/armor/armor_test.go
+++ b/openpgp/armor/armor_test.go
@@ -71,10 +71,29 @@ func TestLongHeader(t *testing.T) {
 }
 
 func TestZeroWidthSpace(t *testing.T) {
-	buf := bytes.NewBuffer([]byte(armorZeroWidthSpace))
-	_, err := Decode(buf)
+	result, err := Decode(bytes.NewBuffer([]byte(armorZeroWidthSpace)))
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	_, err = ioutil.ReadAll(result.Body)
+	if err != nil {
+		t.Fatalf("Error after ReadAll: %+v", err)
+	}
+
+	result, err = Decode(bytes.NewBuffer([]byte(armorMoreZeroWidths)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ioutil.ReadAll(result.Body)
+	if err != nil {
+		t.Fatalf("Error after ReadAll: %+v", err)
+	}
+
+	if result.lReader.crc == nil {
+		// Make sure that ZERO-WIDTH SPACE did not mess with crc reading.
+		t.Error("Expected CRC to be read")
 	}
 }
 
@@ -113,3 +132,13 @@ TxRjs+fJCIFuo71xb1g=
 =/teI
 -----END PGP SIGNATURE-----
 `
+
+const armorMoreZeroWidths = `-----BEGIN PGP SIGNATURE-----` + "\u200b" + `
+Version: GnuPG v1.4.10 (GNU/Linux)
+
+iJwEAAECAAYFAk1Fv/0ACgkQo01+GMIMMbsYTwQAiAw+QAaNfY6WBdplZ/uMAccm` + "\u200b" + `
+4g+81QPmTSGHnetSb6WBiY13kVzK4HQiZH8JSkmmroMLuGeJwsRTEL4wbjRyUKEt
+` + "\u200b" + `p1xwUZDECs234F1xiG5enc5SGlRtP7foLBz9lOsjx+LEcA4sTl5/2eZR9zyFZqWW
+TxRjs+fJCIFuo71xb1g=` + "\u200b" + `
+` + "\u200b" + `=/teI
+-----END PGP SIGNATURE-----`

--- a/openpgp/armor/armor_test.go
+++ b/openpgp/armor/armor_test.go
@@ -70,6 +70,14 @@ func TestLongHeader(t *testing.T) {
 	}
 }
 
+func TestZeroWidthSpace(t *testing.T) {
+	buf := bytes.NewBuffer([]byte(armorZeroWidthSpace))
+	_, err := Decode(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 const armorExample1 = `-----BEGIN PGP SIGNATURE-----
 Version: GnuPG v1.4.10 (GNU/Linux)
 
@@ -94,3 +102,14 @@ okWuf3+xA9ksp1npSY/mDvgHijmjvtpRDe6iUeqfCn8N9u9CBg8geANgaG8+QA4=
 -----END PGP SIGNATURE-----`
 
 const longValueExpected = "0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz"
+
+const armorZeroWidthSpace = `-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1.4.10 (GNU/Linux)
+` + "\u200b" + `
+iJwEAAECAAYFAk1Fv/0ACgkQo01+GMIMMbsYTwQAiAw+QAaNfY6WBdplZ/uMAccm
+4g+81QPmTSGHnetSb6WBiY13kVzK4HQiZH8JSkmmroMLuGeJwsRTEL4wbjRyUKEt
+p1xwUZDECs234F1xiG5enc5SGlRtP7foLBz9lOsjx+LEcA4sTl5/2eZR9zyFZqWW
+TxRjs+fJCIFuo71xb1g=
+=/teI
+-----END PGP SIGNATURE-----
+`


### PR DESCRIPTION
Trim characters that match `unicode.IsSpace` and `\u200b` (zero-width space) from headers and base64 body. Unfortunately there is no way to ask base64 decoder to skip invalid characters, but we can at least try to trim unwanted characters at the beginning or end of lines.

Should fix https://github.com/keybase/client/issues/6996