### PR TITLE
Remove all whitespace when dearmoring (not just trim)

### DIFF
--- a/openpgp/armor/armor.go
+++ b/openpgp/armor/armor.go
@@ -136,7 +136,9 @@ func (l *lineReader) Read(p []byte) (n int, err error) {
 
 	// Clean-up line from whitespace to pass it further (to base64
 	// decoder). This is done after test for CRC and test for
-	// armorEnd. So keys that have whitespace in CRC
+	// armorEnd. Keys that have whitespace in CRC will have CRC
+	// treated as part of the payload and probably fail in base64
+	// reading.
 	line = bytes.Map(func(r rune) rune {
 		if ourIsSpace(r) {
 			return -1

--- a/openpgp/armor/armor.go
+++ b/openpgp/armor/armor.go
@@ -94,7 +94,12 @@ func (l *lineReader) Read(p []byte) (n int, err error) {
 		return
 	}
 
-	line = bytes.TrimFunc(line, ourIsSpace)
+	line = bytes.Map(func(r rune) rune {
+		if ourIsSpace(r) {
+			return -1
+		}
+		return r
+	}, line)
 
 	if len(line) == 5 && line[0] == '=' {
 		// This is the checksum line

--- a/openpgp/armor/armor.go
+++ b/openpgp/armor/armor.go
@@ -94,12 +94,8 @@ func (l *lineReader) Read(p []byte) (n int, err error) {
 		return
 	}
 
-	line = bytes.Map(func(r rune) rune {
-		if ourIsSpace(r) {
-			return -1
-		}
-		return r
-	}, line)
+	// Entry-level cleanup, just trim spaces.
+	line = bytes.TrimFunc(line, ourIsSpace)
 
 	if len(line) == 5 && line[0] == '=' {
 		// This is the checksum line
@@ -137,6 +133,16 @@ func (l *lineReader) Read(p []byte) (n int, err error) {
 		l.crc = nil
 		return 0, io.EOF
 	}
+
+	// Clean-up line from whitespace to pass it further (to base64
+	// decoder). This is done after test for CRC and test for
+	// armorEnd. So keys that have whitespace in CRC
+	line = bytes.Map(func(r rune) rune {
+		if ourIsSpace(r) {
+			return -1
+		}
+		return r
+	}, line)
 
 	n = copy(p, line)
 	bytesToSave := len(line) - n

--- a/openpgp/armor/armor_test.go
+++ b/openpgp/armor/armor_test.go
@@ -97,6 +97,26 @@ func TestZeroWidthSpace(t *testing.T) {
 	}
 }
 
+func TestNoNewlines(t *testing.T) {
+	result, err := Decode(bytes.NewBuffer([]byte(armorNoNewlines)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = ioutil.ReadAll(result.Body); err != nil {
+		t.Fatalf("Error after ReadAll: %+v", err)
+	}
+
+	result, err = Decode(bytes.NewBuffer([]byte(armorNoNewlines2)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = ioutil.ReadAll(result.Body); err != nil {
+		t.Fatalf("Error after ReadAll: %+v", err)
+	}
+}
+
 const armorExample1 = `-----BEGIN PGP SIGNATURE-----
 Version: GnuPG v1.4.10 (GNU/Linux)
 
@@ -142,3 +162,25 @@ iJwEAAECAAYFAk1Fv/0ACgkQo01+GMIMMbsYTwQAiAw+QAaNfY6WBdplZ/uMAccm` + "\u200b" + `
 TxRjs+fJCIFuo71xb1g=` + "\u200b" + `
 ` + "\u200b" + `=/teI
 -----END PGP SIGNATURE-----`
+
+const armorNoNewlines = `-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1.4.10 (GNU/Linux)
+
+iJwEAAECAAYFAk1Fv/0ACgkQo01+GMIMMbsYTwQAiAw+QAaNfY6WBdplZ/uMAccm `+
+`4g+81QPmTSGHnetSb6WBiY13kVzK4HQiZH8JSkmmroMLuGeJwsRTEL4wbjRyUKEt `+
+`p1xwUZDECs234F1xiG5enc5SGlRtP7foLBz9lOsjx+LEcA4sTl5/2eZR9zyFZqWW `+
+`TxRjs+fJCIFuo71xb1g=
+=/teI
+-----END PGP SIGNATURE-----
+`
+
+const armorNoNewlines2 = `-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1.4.10 (GNU/Linux)
+
+iJwEAAECAAYFAk1Fv/0ACgkQo01+GMIMMbsYTwQAiAw+QAaNfY6WBdplZ/uMAccm ` + "\t" +
+`4g+81QPmTSGHnetSb6WBiY13kVzK4HQiZH8JSkmmroMLuGeJwsRTEL4wbjRyUKEt     ` +
+`p1xwUZDECs234F1xiG5enc5SGlRtP7foLBz9lOsjx+LEcA4sTl5/2eZR9zyFZqWW       ` + `
+TxRjs+fJCIFuo71xb1g=
+=/teI
+-----END PGP SIGNATURE-----
+`

--- a/openpgp/armor/armor_test.go
+++ b/openpgp/armor/armor_test.go
@@ -100,15 +100,24 @@ func TestZeroWidthSpace(t *testing.T) {
 func TestNoNewlines(t *testing.T) {
 	decodeAndRead(t, armorNoNewlines)
 	decodeAndRead(t, armorNoNewlines2)
-	decodeAndRead(t, wtfKey)
 }
 
 func TestFoldedCRC(t *testing.T) {
+	// KBPGP does not fail to read here, but it doesn't discover CRC
+	// (discards the folded in CRC as garbage), and it's probably the
+	// right behavior to aim for here.
 	t.Skip("Not sure how to handle this one")
 
 	result := decodeAndRead(t, armorNoNewlinesBrokenCRC)
 	if result.lReader.crc == nil {
 		// Make sure that ZERO-WIDTH SPACE did not mess with crc reading.
+		t.Error("Expected CRC to be read")
+	}
+}
+
+func TestWhitespaceInCRC(t *testing.T) {
+	result := decodeAndRead(t, armorWhitespaceInCRC)
+	if result.lReader.crc == nil {
 		t.Error("Expected CRC to be read")
 	}
 }
@@ -190,5 +199,16 @@ iJwEAAECAAYFAk1Fv/0ACgkQo01+GMIMMbsYTwQAiAw+QAaNfY6WBdplZ/uMAccm ` + "\t" +
 `4g+81QPmTSGHnetSb6WBiY13kVzK4HQiZH8JSkmmroMLuGeJwsRTEL4wbjRyUKEt     ` +
 `p1xwUZDECs234F1xiG5enc5SGlRtP7foLBz9lOsjx+LEcA4sTl5/2eZR9zyFZqWW       ` + `
 TxRjs+fJCIFuo71xb1g==/teI
+-----END PGP SIGNATURE-----
+`
+
+const armorWhitespaceInCRC = `-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1.4.10 (GNU/Linux)
+
+iJwEAAECAAYFAk1Fv/0ACgkQo01+GMIMMbsYTwQAiAw+QAaNfY6WBdplZ/uMAccm ` + "\t" +
+`4g+81QPmTSGHnetSb6WBiY13kVzK4HQiZH8JSkmmroMLuGeJwsRTEL4wbjRyUKEt     ` +
+`p1xwUZDECs234F1xiG5enc5SGlRtP7foLBz9lOsjx+LEcA4sTl5/2eZR9zyFZqWW       ` + `
+TxRjs+fJCIFuo71xb1g=
+=/teI` + "\u200b " + `
 -----END PGP SIGNATURE-----
 `

--- a/openpgp/read_test.go
+++ b/openpgp/read_test.go
@@ -890,6 +890,11 @@ func TestIllformedArmors(t *testing.T) {
 	if err != nil || len(el) != 1 {
 		t.Fatalf("Failed to read noCRCKey: %v", err)
 	}
+
+	el, err = ReadArmoredKeyRing(bytes.NewBufferString(spacesInsteadOfNewlinesKey))
+	if err != nil || len(el) != 1 {
+		t.Fatalf("Failed to read spacesInsteadOfNewlinesKey: %v", err)
+	}
 }
 
 const testKey1KeyId = 0xA34D7E18C20C31BB
@@ -2631,6 +2636,17 @@ const noNewLinesKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
 	"7gvM60G0E1JFQUQgVEVTVCBHTy1DUllQVE+IeQQTFggAIQUCWQoA2QIbAwULCQgH" +
 	"AgYVCAkKCwIEFgIDAQIeAQIXgAAKCRBEkPOnE4+R/RiKAQDvIhM74qEtKSbTtu50" +
 	"mMB49eTAMg/MogyFA8SUCbStPAEAxdxSKX1hFYFP4N8ML8BgLOJG4PXAdQ8wnfXD" +
+	`vJxN/AQ=
+=apgr
+-----END PGP PUBLIC KEY BLOCK-----`
+
+const spacesInsteadOfNewlinesKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+` +
+	"mDMEWQoA2RYJKwYBBAHaRw8BAQdAQkGkdMrckk67dh9MKxeCa8PJsTnMJ+oDgCJ9 " +
+	"7gvM60G0E1JFQUQgVEVTVCBHTy1DUllQVE+IeQQTFggAIQUCWQoA2QIbAwULCQgH " +
+	"AgYVCAkKCwIEFgIDAQIeAQIXgAAKCRBEkPOnE4+R/RiKAQDvIhM74qEtKSbTtu50 " +
+	"mMB49eTAMg/MogyFA8SUCbStPAEAxdxSKX1hFYFP4N8ML8BgLOJG4PXAdQ8wnfXD " +
 	`vJxN/AQ=
 =apgr
 -----END PGP PUBLIC KEY BLOCK-----`


### PR DESCRIPTION
Related to this issue:

https://github.com/keybase/keybase-issues/issues/3067

Which was a failure to parse this ASCII armored bundle: https://gist.github.com/zapu/cb935798e06b1d5bed12ad61824b9610

Newlines were replaced by spaces. `gpg` doesn't complain, this PR makes `go-crypto` be able to parse it as well.

This is not necessarily the right way of fixing that bug though!

