### PR TITLE
Support multiple (nested) signatures

### DIFF
--- a/openpgp/nested_sig_test.go
+++ b/openpgp/nested_sig_test.go
@@ -42,6 +42,14 @@ func TestMultisig(t *testing.T) {
             return fmt.Errorf("Expected MultiSig to be true")
         }
 
+        if md.SignedBy == nil {
+            return fmt.Errorf("Message wasn't signed (md is %+v)", md)
+        }
+
+        if md.SignedBy.PublicKey != keys[0].PrimaryKey {
+            return fmt.Errorf("Message wasn't by expected key (SignedBy is %p)", md.SignedBy)
+        }
+
         _, err = ioutil.ReadAll(md.UnverifiedBody)
         if err != nil {
             return err
@@ -51,12 +59,8 @@ func TestMultisig(t *testing.T) {
             return fmt.Errorf("md.SignatureError: %s", md.SignatureError)
         }
 
-        if md.SignedBy == nil || (md.Signature == nil && md.SignatureV3 == nil) {
-            return fmt.Errorf("Message wasn't signed (md is %+v)", md)
-        }
-
-        if md.SignedBy.PublicKey != keys[0].PrimaryKey {
-            return fmt.Errorf("Message wasn't by expected key (SignedBy is %p)", md.SignedBy)
+        if md.Signature == nil && md.SignatureV3 == nil {
+            return fmt.Errorf("Signature is nil after reading (md is %+v)", md)
         }
 
         return nil

--- a/openpgp/nested_sig_test.go
+++ b/openpgp/nested_sig_test.go
@@ -89,36 +89,36 @@ func TestMultisig(t *testing.T) {
 }
 
 func TestMultisigMalformed(t *testing.T) {
-    keys, err := ReadArmoredKeyRing(bytes.NewBufferString(testKey2))
-    if err != nil {
-        t.Fatal(err)
-        return
-    }
+	keys, err := ReadArmoredKeyRing(bytes.NewBufferString(testKey2))
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
 
-    sig, err := armor.Decode(strings.NewReader(testSignatureMalformed))
-    if err != nil {
-        t.Fatalf("Got error during decode: %v", err)
-    }
+	sig, err := armor.Decode(strings.NewReader(testSignatureMalformed))
+	if err != nil {
+		t.Fatalf("Got error during decode: %v", err)
+	}
 
-    md, err := ReadMessage(sig.Body, keys, nil, nil)
-    if err != nil {
-        t.Fatalf("Got error during ReadMessage: %v", err)
-    }
+	md, err := ReadMessage(sig.Body, keys, nil, nil)
+	if err != nil {
+		t.Fatalf("Got error during ReadMessage: %v", err)
+	}
 
-    if !md.MultiSig {
-        t.Fatal("Expected MultiSig to be true")
-    }
+	if !md.MultiSig {
+		t.Fatal("Expected MultiSig to be true")
+	}
 
-    _, err = ioutil.ReadAll(md.UnverifiedBody)
-    if err != nil {
-        t.Fatalf("Got error during ReadAll: %v", err)
-    }
+	_, err = ioutil.ReadAll(md.UnverifiedBody)
+	if err != nil {
+		t.Fatalf("Got error during ReadAll: %v", err)
+	}
 
-    if md.SignatureError == nil || md.Signature != nil {
-        t.Fatalf("Expected SignatureError, got nil")
-    }
+	if md.SignatureError == nil || md.Signature != nil {
+		t.Fatalf("Expected SignatureError, got nil")
+	}
 
-    t.Logf("SignatureError is: %v", md.SignatureError)
+	t.Logf("SignatureError is: %v", md.SignatureError)
 }
 
 const testKey1 = `-----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/openpgp/nested_sig_test.go
+++ b/openpgp/nested_sig_test.go
@@ -42,8 +42,12 @@ func TestMultisig(t *testing.T) {
 			return fmt.Errorf("Expected MultiSig to be true")
 		}
 
+		if md.SignedByKeyId == 0 {
+			return fmt.Errorf("SignedByKeyId should never be zero, even if keyring doesn't contain good key")
+		}
+
 		if md.SignedBy == nil {
-			return fmt.Errorf("Message wasn't signed (md is %+v)", md)
+			return fmt.Errorf("Couldn't find key message was signed with or message wasn't signed (md is %+v)", md)
 		}
 
 		if md.SignedBy.PublicKey != keys[0].PrimaryKey {
@@ -83,9 +87,11 @@ func TestMultisig(t *testing.T) {
 	}
 
 	t.Logf("Trying entirely unrelated key from different test file")
-	if err := tryWithKey(badkey); err == nil {
+	err = tryWithKey(badkey)
+	if err == nil {
 		t.Error("Expected an error but got nil when trying unrelated key.")
 	}
+	t.Logf("When trying with bad key, error was: %s", err)
 }
 
 func TestMultisigMalformed(t *testing.T) {

--- a/openpgp/nested_sig_test.go
+++ b/openpgp/nested_sig_test.go
@@ -1,0 +1,124 @@
+package openpgp
+
+import (
+    "bytes"
+    "io/ioutil"
+    "strings"
+    "testing"
+    "fmt"
+
+    "github.com/keybase/go-crypto/openpgp/armor"
+)
+
+func TestMultisig(t *testing.T) {
+    kring1, err := ReadArmoredKeyRing(bytes.NewBufferString(testKey1))
+    if err != nil {
+        t.Error(err)
+        return
+    }
+
+    kring2, err := ReadArmoredKeyRing(bytes.NewBufferString(testKey2))
+    if err != nil {
+        t.Error(err)
+        return
+    }
+
+    if len(kring1) != 1 && len(kring2) != 1 {
+        t.Fatalf("Expected both keyrings to only have one key each: len 1: %d len 2: %d", len(kring1), len(kring2))
+    }
+
+    tryWithKey := func (keys EntityList) error {
+        sig, err := armor.Decode(strings.NewReader(testSignature))
+        if err != nil {
+            return err
+        }
+
+        md, err := ReadMessage(sig.Body, keys, nil, nil)
+        if err != nil {
+            return err
+        }
+
+        if !md.MultiSig {
+            return fmt.Errorf("Expected MultiSig to be true")
+        }
+
+        _, err = ioutil.ReadAll(md.UnverifiedBody)
+        if err != nil {
+            return err
+        }
+
+        if md.SignatureError != nil {
+            return fmt.Errorf("md.SignatureError: %s", md.SignatureError)
+        }
+
+        if md.SignedBy == nil || (md.Signature == nil && md.SignatureV3 == nil) {
+            return fmt.Errorf("Message wasn't signed (md is %+v)", md)
+        }
+
+        if md.SignedBy.PublicKey != keys[0].PrimaryKey {
+            return fmt.Errorf("Message wasn't by expected key (SignedBy is %p)", md.SignedBy)
+        }
+
+        return nil
+    }
+
+    badkey, err := ReadArmoredKeyRing(bytes.NewBufferString(matthiasuKey))
+    if err != nil {
+        t.Error(err)
+        return
+    }
+
+    t.Logf("Trying keyring 1")
+    if err := tryWithKey(kring1); err != nil {
+        t.Error(err)
+    }
+
+    t.Logf("Trying keyring 2")
+    if err := tryWithKey(kring2); err != nil {
+        t.Error(err)
+    }
+
+    t.Logf("Trying entirely unrelated key from different test file")
+    if err := tryWithKey(badkey); err == nil {
+        t.Error("Expected an error but got nil when trying unrelated key.")
+    }
+}
+
+const testKey1 = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEWfcV/BYJKwYBBAHaRw8BAQdAYhAuI4LPgxnu8MDU/XJpSlfCFPelz58v5QpU
+9R9MtFa0ClRlc3QgS2V5IDGIeQQTFggAIQUCWfcV/AIbAwULCQgHAgYVCAkKCwIE
+FgIDAQIeAQIXgAAKCRCc9gMcYqzhOWz5AP91QOM2xFiy5FZ+suqpP5zbygMNe/PJ
+wunDkjryQRaWqgEAjalogSO20NeTEbDBWiglggMvJrTFXMqdsZ5bdUkoSQi4OARZ
+9xX8EgorBgEEAZdVAQUBAQdAIXy/6CNrP/Tq6uDnTu9Vra8Qc05uGY18gUqou9/0
+m1wDAQgHiGEEGBYIAAkFAln3FfwCGwwACgkQnPYDHGKs4TkTYwEA9JWX8sASAY6u
+NSuMuq3f3fKwYVR3kB0hYRd7ffic+aABALBDGedfGTfjKLWAqd+NFO4fKlQJjg0Y
++EnrmcTzas4G
+=JK7o
+-----END PGP PUBLIC KEY BLOCK-----
+`
+
+const testKey2 = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEWfcWjxYJKwYBBAHaRw8BAQdAxsmWcp2FwAiRHylbOrDnoKKUBAa1wgQlE1mJ
+fNj4EFS0ClRlc3QgS2V5IDKIeQQTFggAIQUCWfcWjwIbAwULCQgHAgYVCAkKCwIE
+FgIDAQIeAQIXgAAKCRCIHHukx/1YbM3dAQDNiAF2ZqxrDvxv5chMeazuvsu9o5J8
+mtpPludqpWKsvAD6AsH0fhDeIwKVBk1uigw3ut7VKyyNSSNezy3RczengQy4OARZ
+9xaPEgorBgEEAZdVAQUBAQdAF1hhJLcRj77GF+lc9gEVziFZ1yJW/8LYSMZ0AAo9
+kkgDAQgHiGEEGBYIAAkFAln3Fo8CGwwACgkQiBx7pMf9WGxlJgD/RriX0jfA3Hjl
+pSCtbGRJGm6LZgYEn9XHzfmZ+ZTG9bsA/AxYjMrv4I3Ft4x6ogrqzvxmcga3zgGc
+QjcG/YKbNUQJ
+=/+FB
+-----END PGP PUBLIC KEY BLOCK-----
+`
+
+const testSignature = `-----BEGIN PGP MESSAGE-----
+
+owGbwMvMwCHWIVO95PjfiByGCWDunG/MMklrHloynhZLYoj8bmpdgQq4OuJYGMQ4
+GNhYmUCyDFycAjAtVeyMDAsPbJoqV7fr73PmkwouPLvPX02Oeye648Tq72GOz+68
+lTdiZLigI+QhMS++YiL/9uLLKyZmlnX3iZ89rLYhTKZe2b5JHIv5MBeCzP9zUvnk
+xI4vmaJe3MJav1zjZZc67ZSJYVy9+Q33resy8X0M/4Mmhrs7zvyssnTjiTOTPzus
+uXp/8adNSepq6kncd9iiU5kB
+=QVa3
+-----END PGP MESSAGE-----
+`

--- a/openpgp/read.go
+++ b/openpgp/read.go
@@ -345,6 +345,13 @@ func (scr *signatureCheckReader) Read(buf []byte) (n int, err error) {
 			var p packet.Packet
 			p, scr.md.SignatureError = scr.packets.Next()
 			if scr.md.SignatureError != nil {
+				if scr.md.MultiSig {
+					// If we are in MultiSig, we might have found other
+					// signature that cannot be verified using our key.
+					// Clear Signature field so it's clear for consumers
+					// that this message failed to verify.
+					scr.md.Signature = nil
+				}
 				return
 			}
 

--- a/openpgp/read.go
+++ b/openpgp/read.go
@@ -248,11 +248,14 @@ FindLiteralData:
 			}
 		case *packet.OnePassSignature:
 			if md.IsSigned {
+				// If IsSigned is set, it means we have multiple
+				// OnePassSignature packets.
 				md.MultiSig = true
 				if md.SignedBy != nil {
-					// Consumer is going to check message validity against
-					// specific key, continue with that key instead of trying
-					// to find one for another sig.
+					// We've already found the signature we were looking
+					// for, made by key that we had in keyring and can
+					// check signature against. Continue with that instead
+					// of trying to find another.
 					continue FindLiteralData
 				}
 			}

--- a/openpgp/read_test.go
+++ b/openpgp/read_test.go
@@ -116,7 +116,7 @@ func checkSignedMessage(t *testing.T, signedHex, expected string) {
 		return
 	}
 
-	if !md.IsSigned || md.SignedByKeyId != 0xa34d7e18c20c31bb || md.SignedBy == nil || md.IsEncrypted || md.IsSymmetricallyEncrypted || len(md.EncryptedToKeyIds) != 0 || md.IsSymmetricallyEncrypted {
+	if !md.IsSigned || md.SignedByKeyId != 0xa34d7e18c20c31bb || md.SignedBy == nil || md.IsEncrypted || md.IsSymmetricallyEncrypted || len(md.EncryptedToKeyIds) != 0 || md.IsSymmetricallyEncrypted || md.MultiSig {
 		t.Errorf("bad MessageDetails: %#v", md)
 	}
 
@@ -209,7 +209,7 @@ func TestSignedEncryptedMessage(t *testing.T) {
 			return
 		}
 
-		if !md.IsSigned || md.SignedByKeyId != test.signedByKeyId || md.SignedBy == nil || !md.IsEncrypted || md.IsSymmetricallyEncrypted || len(md.EncryptedToKeyIds) == 0 || md.EncryptedToKeyIds[0] != test.encryptedToKeyId {
+		if !md.IsSigned || md.SignedByKeyId != test.signedByKeyId || md.SignedBy == nil || !md.IsEncrypted || md.IsSymmetricallyEncrypted || len(md.EncryptedToKeyIds) == 0 || md.EncryptedToKeyIds[0] != test.encryptedToKeyId || md.MultiSig {
 			t.Errorf("#%d: bad MessageDetails: %#v", i, md)
 		}
 
@@ -905,7 +905,7 @@ func TestSignedTextMessageNoSignature(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !md.IsSigned || md.SignedByKeyId != 0xa34d7e18c20c31bb || md.SignedBy == nil || md.IsEncrypted || md.IsSymmetricallyEncrypted || len(md.EncryptedToKeyIds) != 0 || md.IsSymmetricallyEncrypted {
+	if !md.IsSigned || md.SignedByKeyId != 0xa34d7e18c20c31bb || md.SignedBy == nil || md.IsEncrypted || md.IsSymmetricallyEncrypted || len(md.EncryptedToKeyIds) != 0 || md.IsSymmetricallyEncrypted || md.MultiSig {
 		t.Errorf("bad MessageDetails: %#v", md)
 	}
 

--- a/openpgp/read_test.go
+++ b/openpgp/read_test.go
@@ -897,6 +897,31 @@ func TestIllformedArmors(t *testing.T) {
 	}
 }
 
+func TestSignedTextMessageNoSignature(t *testing.T) {
+	kring, _ := ReadKeyRing(readerFromHex(testKeys1And2Hex))
+
+	md, err := ReadMessage(readerFromHex(signedTextMessageMalformed), kring, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !md.IsSigned || md.SignedByKeyId != 0xa34d7e18c20c31bb || md.SignedBy == nil || md.IsEncrypted || md.IsSymmetricallyEncrypted || len(md.EncryptedToKeyIds) != 0 || md.IsSymmetricallyEncrypted {
+		t.Errorf("bad MessageDetails: %#v", md)
+	}
+
+	contents, err := ioutil.ReadAll(md.UnverifiedBody)
+	if err != nil {
+		t.Errorf("error reading UnverifiedBody: %s", err)
+	}
+	if string(contents) != signedTextInput {
+		t.Errorf("bad UnverifiedBody got:%s want:%s", string(contents), signedTextInput)
+	}
+	if md.SignatureError == nil || md.Signature != nil {
+		t.Fatalf("Expected SignatureError, got nil")
+	}
+	t.Logf("SignatureError is: %s", md.SignatureError)
+}
+
 const testKey1KeyId = 0xA34D7E18C20C31BB
 const testKey3KeyId = 0x338934250CCC0360
 
@@ -922,6 +947,11 @@ const dsaElGamalTestKeysHex = "9501e1044dfcb16a110400aa3e5c1a1f43dd28c2ffae8abf5
 const signedMessageHex = "a3019bc0cbccc0c4b8d8b74ee2108fe16ec6d3ca490cbe362d3f8333d3f352531472538b8b13d353b97232f352158c20943157c71c16064626063656269052062e4e01987e9b6fccff4b7df3a34c534b23e679cbec3bc0f8f6e64dfb4b55fe3f8efa9ce110ddb5cd79faf1d753c51aecfa669f7e7aa043436596cccc3359cb7dd6bbe9ecaa69e5989d9e57209571edc0b2fa7f57b9b79a64ee6e99ce1371395fee92fec2796f7b15a77c386ff668ee27f6d38f0baa6c438b561657377bf6acff3c5947befd7bf4c196252f1d6e5c524d0300"
 
 const signedTextMessageHex = "a3019bc0cbccc8c4b8d8b74ee2108fe16ec6d36a250cbece0c178233d3f352531472538b8b13d35379b97232f352158ca0b4312f57c71c1646462606365626906a062e4e019811591798ff99bf8afee860b0d8a8c2a85c3387e3bcf0bb3b17987f2bbcfab2aa526d930cbfd3d98757184df3995c9f3e7790e36e3e9779f06089d4c64e9e47dd6202cb6e9bc73c5d11bb59fbaf89d22d8dc7cf199ddf17af96e77c5f65f9bbed56f427bd8db7af37f6c9984bf9385efaf5f184f986fb3e6adb0ecfe35bbf92d16a7aa2a344fb0bc52fb7624f0200"
+
+// Same message as signedTextMessageHex but "signature packet" is
+// dropped from the end. So this message claims to be signed but it
+// cannot be verified, so verification should fail.
+const signedTextMessageMalformed = "900d03010201a34d7e18c20c31bb01cb2674004d4300d05369676e6564206d6573736167650d0a6c696e6520320d0a6c696e6520330d0a"
 
 const signedEncryptedMessageHex = "848c032a67d68660df41c70103ff5789d0de26b6a50c985a02a13131ca829c413a35d0e6fa8d6842599252162808ac7439c72151c8c6183e76923fe3299301414d0c25a2f06a2257db3839e7df0ec964773f6e4c4ac7ff3b48c444237166dd46ba8ff443a5410dc670cb486672fdbe7c9dfafb75b4fea83af3a204fe2a7dfa86bd20122b4f3d2646cbeecb8f7be8d2c03b018bd210b1d3791e1aba74b0f1034e122ab72e760492c192383cf5e20b5628bd043272d63df9b923f147eb6091cd897553204832aba48fec54aa447547bb16305a1024713b90e77fd0065f1918271947549205af3c74891af22ee0b56cd29bfec6d6e351901cd4ab3ece7c486f1e32a792d4e474aed98ee84b3f591c7dff37b64e0ecd68fd036d517e412dcadf85840ce184ad7921ad446c4ee28db80447aea1ca8d4f574db4d4e37688158ddd19e14ee2eab4873d46947d65d14a23e788d912cf9a19624ca7352469b72a83866b7c23cb5ace3deab3c7018061b0ba0f39ed2befe27163e5083cf9b8271e3e3d52cc7ad6e2a3bd81d4c3d7022f8d"
 


### PR DESCRIPTION
`ReadMessage` is now able to read multiple signatures, instead of bailing out with "unsupported" error. It will only check the first key it finds, though, there is no API for checking multiple signatures against multiple keys.