### PR TITLE
Fix test failures on Go 1.10.

### DIFF
--- a/ocsp/ocsp_test.go
+++ b/ocsp/ocsp_test.go
@@ -34,11 +34,11 @@ func TestOCSPDecode(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(resp.ThisUpdate, expected.ThisUpdate) {
-		t.Errorf("resp.ThisUpdate: got %d, want %d", resp.ThisUpdate, expected.ThisUpdate)
+		t.Errorf("resp.ThisUpdate: got %v, want %v", resp.ThisUpdate, expected.ThisUpdate)
 	}
 
 	if !reflect.DeepEqual(resp.NextUpdate, expected.NextUpdate) {
-		t.Errorf("resp.NextUpdate: got %d, want %d", resp.NextUpdate, expected.NextUpdate)
+		t.Errorf("resp.NextUpdate: got %v, want %v", resp.NextUpdate, expected.NextUpdate)
 	}
 
 	if resp.Status != expected.Status {
@@ -220,15 +220,15 @@ func TestOCSPResponse(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(resp.ThisUpdate, template.ThisUpdate) {
-		t.Errorf("resp.ThisUpdate: got %d, want %d", resp.ThisUpdate, template.ThisUpdate)
+		t.Errorf("resp.ThisUpdate: got %v, want %v", resp.ThisUpdate, template.ThisUpdate)
 	}
 
 	if !reflect.DeepEqual(resp.NextUpdate, template.NextUpdate) {
-		t.Errorf("resp.NextUpdate: got %d, want %d", resp.NextUpdate, template.NextUpdate)
+		t.Errorf("resp.NextUpdate: got %v, want %v", resp.NextUpdate, template.NextUpdate)
 	}
 
 	if !reflect.DeepEqual(resp.RevokedAt, template.RevokedAt) {
-		t.Errorf("resp.RevokedAt: got %d, want %d", resp.RevokedAt, template.RevokedAt)
+		t.Errorf("resp.RevokedAt: got %v, want %v", resp.RevokedAt, template.RevokedAt)
 	}
 
 	if !reflect.DeepEqual(resp.Extensions, template.ExtraExtensions) {
@@ -236,7 +236,7 @@ func TestOCSPResponse(t *testing.T) {
 	}
 
 	if !resp.ProducedAt.Equal(producedAt) {
-		t.Errorf("resp.ProducedAt: got %d, want %d", resp.ProducedAt, producedAt)
+		t.Errorf("resp.ProducedAt: got %v, want %v", resp.ProducedAt, producedAt)
 	}
 
 	if resp.Status != template.Status {

--- a/openpgp/keys_test.go
+++ b/openpgp/keys_test.go
@@ -55,7 +55,7 @@ func TestMissingCrossSignature(t *testing.T) {
 		t.Errorf("Should have gotten 1 key; got %d", len(keys))
 	}
 	if err != nil {
-		t.Errorf("Should not have failed, but got: %v\n")
+		t.Errorf("Should not have failed, but got: %v\n", err)
 	}
 
 	key := keys[0]
@@ -88,7 +88,7 @@ func TestInvalidCrossSignature(t *testing.T) {
 		t.Errorf("Should have gotten 1 key; got %d", len(keys))
 	}
 	if err != nil {
-		t.Errorf("Should not have failed, but got: %v\n")
+		t.Errorf("Should not have failed, but got: %v\n", err)
 	}
 
 	key := keys[0]
@@ -331,7 +331,7 @@ func TestKeyWithoutUID(t *testing.T) {
 	if se, ok := err.(pgpErrors.StructuralError); !ok {
 		t.Fatal("expected a structural error")
 	} else if strings.Index(se.Error(), "entity without any identities") < 0 {
-		t.Fatal("Got wrong error: %s", se.Error())
+		t.Fatalf("Got wrong error: %s", se.Error())
 	}
 }
 

--- a/openpgp/read_test.go
+++ b/openpgp/read_test.go
@@ -494,7 +494,7 @@ func TestGNUS2KDummySigningSubkey(t *testing.T) {
 	key := testSerializePrivate(t, gnuDummyS2KPrivateKeyWithSigningSubkey, gnuDummyS2KPrivateKeyWithSigningSubkeyPassphrase, 2)
 	_, err := trySigning(key)
 	if err != nil {
-		t.Fatal("Got a signing failure: %s\n", err)
+		t.Fatalf("Got a signing failure: %v\n", err)
 	}
 }
 

--- a/openpgp/write_test.go
+++ b/openpgp/write_test.go
@@ -176,7 +176,7 @@ func TestNewEntity(t *testing.T) {
 		t.Errorf("failed to find bit length: %s", err)
 	}
 	if int(bl) != defaultRSAKeyBits {
-		t.Errorf("BitLength %v, expected %v", defaultRSAKeyBits)
+		t.Errorf("BitLength %v, expected %v", bl, defaultRSAKeyBits)
 	}
 
 	// Check bit-length with a config.
@@ -334,7 +334,7 @@ func TestEncryption(t *testing.T) {
 			signKey, _ := kring[0].signingKey(testTime)
 			expectedKeyId := signKey.PublicKey.KeyId
 			if md.SignedByKeyId != expectedKeyId {
-				t.Errorf("#%d: message signed by wrong key id, got: %d, want: %d", i, *md.SignedBy, expectedKeyId)
+				t.Errorf("#%d: message signed by wrong key id, got: %d, want: %d", i, md.SignedByKeyId, expectedKeyId)
 			}
 			if md.SignedBy == nil {
 				t.Errorf("#%d: failed to find the signing Entity", i)


### PR DESCRIPTION
I maintain the Fedora package of keybase/go-crypto, and the recent update to go 1.10 (slated to appear in Fedora 28) triggered a few test failures due to `go vet` being [run by default now](https://golang.org/doc/go1.10#test). It looks like you might have already taken an earlier pass at it; this patch just grabs a couple of stragglers.