### PR TITLE
Add tests for AttachedSign

### DIFF
--- a/openpgp/keys_test.go
+++ b/openpgp/keys_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keybase/go-crypto/openpgp/armor"
 	pgpErrors "github.com/keybase/go-crypto/openpgp/errors"
 	"github.com/keybase/go-crypto/openpgp/packet"
-	"golang.org/x/crypto/openpgp/armor"
 )
 
 func TestKeyExpiry(t *testing.T) {


### PR DESCRIPTION
https://github.com/keybase/go-crypto/pull/66 made it apparent that we do not have any tests for `AttachedSign`. This PR adds a quick round-trip tests for armored attached signatures with different compression settings.