### PR TITLE
ECC key generation + misc fixes

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -118,7 +118,8 @@ func (e *Entity) primaryIdentity() *Identity {
 func (e *Entity) encryptionKey(now time.Time) (Key, bool) {
 	candidateSubkey := -1
 
-	// Iterate the keys to find the newest key
+	// Iterate the keys to find the newest, non-revoked key that can
+	// encrypt.
 	var maxTime time.Time
 	for i, subkey := range e.Subkeys {
 
@@ -172,13 +173,18 @@ func (e *Entity) encryptionKey(now time.Time) (Key, bool) {
 func (e *Entity) signingKey(now time.Time) (Key, bool) {
 	candidateSubkey := -1
 
+	// Iterate the keys to find the newest, non-revoked key that can
+	// sign.
+	var maxTime time.Time
 	for i, subkey := range e.Subkeys {
 		if (!subkey.Sig.FlagsValid || subkey.Sig.FlagSign) &&
 			subkey.PrivateKey.PrivateKey != nil &&
 			subkey.PublicKey.PubKeyAlgo.CanSign() &&
+			!subkey.Sig.KeyExpired(now) &&
 			subkey.Revocation == nil &&
-			!subkey.Sig.KeyExpired(now) {
+			(maxTime.IsZero() || subkey.Sig.CreationTime.After(maxTime)) {
 			candidateSubkey = i
+			maxTime = subkey.Sig.CreationTime
 			break
 		}
 	}

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -89,6 +89,13 @@ func NewECDSAPrivateKey(currentTime time.Time, priv *ecdsa.PrivateKey) *PrivateK
 	return pk
 }
 
+func NewECDHPrivateKey(currentTime time.Time, priv *ecdh.PrivateKey) *PrivateKey {
+	pk := new(PrivateKey)
+	pk.PublicKey = *NewECDHPublicKey(currentTime, &priv.PublicKey)
+	pk.PrivateKey = priv
+	return pk
+}
+
 func (pk *PrivateKey) parse(r io.Reader) (err error) {
 	err = (&pk.PublicKey).parse(r)
 	if err != nil {

--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -28,6 +28,7 @@ import (
 	"github.com/keybase/go-crypto/openpgp/elgamal"
 	"github.com/keybase/go-crypto/openpgp/errors"
 	"github.com/keybase/go-crypto/rsa"
+	"github.com/keybase/go-crypto/openpgp/s2k"
 )
 
 var (
@@ -324,6 +325,28 @@ func NewElGamalPublicKey(creationTime time.Time, pub *elgamal.PublicKey) *Public
 	return pk
 }
 
+func getCurveOid(curve elliptic.Curve) (res []byte, err error) {
+	switch curve {
+	case elliptic.P256():
+		res = oidCurveP256
+	case elliptic.P384():
+		res = oidCurveP384
+	case elliptic.P521():
+		res = oidCurveP521
+	case brainpool.P256r1():
+		res = oidCurveP256r1
+	case brainpool.P384r1():
+		res = oidCurveP384r1
+	case brainpool.P512r1():
+		res = oidCurveP512r1
+	case curve25519.Cv25519():
+		res = oidCurve25519
+	default:
+		err = errors.UnsupportedError("unknown curve")
+	}
+	return
+}
+
 func NewECDSAPublicKey(creationTime time.Time, pub *ecdsa.PublicKey) *PublicKey {
 	pk := &PublicKey{
 		CreationTime: creationTime,
@@ -331,22 +354,34 @@ func NewECDSAPublicKey(creationTime time.Time, pub *ecdsa.PublicKey) *PublicKey 
 		PublicKey:    pub,
 		ec:           new(ecdsaKey),
 	}
-	switch pub.Curve {
-	case elliptic.P256():
-		pk.ec.oid = oidCurveP256
-	case elliptic.P384():
-		pk.ec.oid = oidCurveP384
-	case elliptic.P521():
-		pk.ec.oid = oidCurveP521
-	case brainpool.P256r1():
-		pk.ec.oid = oidCurveP256r1
-	case brainpool.P384r1():
-		pk.ec.oid = oidCurveP384r1
-	case brainpool.P512r1():
-		pk.ec.oid = oidCurveP512r1
+	oid, _ := getCurveOid(pub.Curve)
+	pk.ec.oid = oid
+	bs, bitLen := ecdh.Marshal(pub.Curve, pub.X, pub.Y)
+	pk.ec.p.bytes = bs
+	pk.ec.p.bitLength = uint16(bitLen)
+
+	pk.setFingerPrintAndKeyId()
+	return pk
+}
+
+func NewECDHPublicKey(creationTime time.Time, pub *ecdh.PublicKey) *PublicKey {
+	pk := &PublicKey{
+		CreationTime: creationTime,
+		PubKeyAlgo:   PubKeyAlgoECDH,
+		PublicKey:    pub,
+		ec:           new(ecdsaKey),
 	}
-	pk.ec.p.bytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y)
-	pk.ec.p.bitLength = uint16(8 * len(pk.ec.p.bytes))
+	oid, _ := getCurveOid(pub.Curve)
+	pk.ec.oid = oid
+	bs, bitLen := ecdh.Marshal(pub.Curve, pub.X, pub.Y)
+	pk.ec.p.bytes = bs
+	pk.ec.p.bitLength = uint16(bitLen)
+
+	hashbyte, _ := s2k.HashToHashId(crypto.SHA512)
+	pk.ecdh = &ecdhKdf{
+		KdfHash: kdfHashFunction(hashbyte),
+		KdfAlgo: kdfAlgorithm(CipherAES256),
+	}
 
 	pk.setFingerPrintAndKeyId()
 	return pk


### PR DESCRIPTION
While trying to repro some user issues, I needed to create a bunch of keys with different parameters. I looked into EC key generation and turns out there was a couple of serialization issues that made it impossible to serialize key bundles with EC keys in them; and also few other issues that obscured real bugs.

This PR fixes these issues, adds *experimental* EC key generation function and adds a test that generates a key, serializes it, de-serializes, and then tries to encrypt that keybundle.