### PR TITLE
Set pk.PublicKey and export EdDSA seed

### DIFF
--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -44,6 +44,10 @@ type EdDSAPrivateKey struct {
 	seed parsedMPI
 }
 
+func (e *EdDSAPrivateKey) Seed() []byte {
+	return e.seed.bytes
+}
+
 func (e *EdDSAPrivateKey) Sign(digest []byte) (R, S []byte, err error) {
 	r := bytes.NewReader(e.seed.bytes)
 	publicKey, privateKey, err := ed25519.GenerateKey(r)

--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -418,6 +418,9 @@ func (pk *PublicKey) parse(r io.Reader) (err error) {
 			return err
 		}
 		err = pk.edk.check()
+		if err == nil {
+			pk.PublicKey = ed25519.PublicKey(pk.edk.p.bytes[1:])
+		}
 	case PubKeyAlgoECDSA:
 		pk.ec = new(ecdsaKey)
 		if err = pk.ec.parse(r); err != nil {


### PR DESCRIPTION
 * Add interoperability with RFC 8032, export ed25519 private key seed (same as upstream: https://godoc.org/golang.org/x/crypto/ed25519#PrivateKey.Seed )
 * Fill PublicKey.PublicKey for PubKeyAlgoEdDSA as other Algos