### PR TITLE
Find armor CRC even when it's folded to previous line

### DIFF
--- a/openpgp/armor/armor.go
+++ b/openpgp/armor/armor.go
@@ -102,7 +102,7 @@ func (l *lineReader) Read(p []byte) (n int, err error) {
 	line = bytes.TrimFunc(line, ourIsSpace)
 
 	foldedChecksum := false
-	if len(line) >= 5 && line[len(line)-5] == '=' {
+	if len(line) >= 5 && line[len(line)-5] == '=' && line[len(line)-4] != '=' {
 		// This is the checksum line. Checksum should appear on separate line,
 		// but some key bundles don't have a newline between main payload and
 		// the checksum, and we try to support that.

--- a/openpgp/armor/armor_test.go
+++ b/openpgp/armor/armor_test.go
@@ -161,7 +161,6 @@ func TestFoldedCRC(t *testing.T) {
 	// (discards the folded in CRC as garbage), and it's probably the
 	// right behavior to aim for here.
 
-	fmt.Printf("%q\n", armorNoNewlinesBrokenCRC)
 	result, _ := decodeAndReadAll(t, armorNoNewlinesBrokenCRC)
 	if result.lReader.crc == nil {
 		// Make sure that ZERO-WIDTH SPACE did not mess with crc reading.


### PR DESCRIPTION
Allow armors like:
```
-----BEGIN PGP ARMORED FILE-----
Comment: Use "gpg --dearmor" for unpacking

aGVsbG8gd29ybGQgMQo==hvYi
-----END PGP ARMORED FILE-----
```

where the `=hvYi` checksum is folded into previous line with data.

we need to do some gymnastics in our streaming parser to support that. If we encounter a line that ends with a checksum - so this also match "checksum lines", where the checksum is on separate line - if there is additional data before the checksum, make sure it's returned as well. Then try to skip empty lines looking for `armorEnd`.