### PR TITLE
Fix an OpenPGP attached signature hash algorithm bug

### DIFF
--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -469,7 +469,7 @@ func AttachedSign(out io.WriteCloser, signed Entity, hints *FileHints,
 		}
 	}
 
-	hasher := crypto.SHA512
+	hasher := config.Hash() // defaults to SHA-256
 
 	ops := &packet.OnePassSignature{
 		SigType:    packet.SigTypeBinary,


### PR DESCRIPTION
It only has one side effect - the default for this particular signing method (and really the only hash method used in Keybase) will be changed to SHA-256.